### PR TITLE
Improve reference similarity computations

### DIFF
--- a/video_processing/README.md
+++ b/video_processing/README.md
@@ -262,11 +262,21 @@ You may filter your videos matching with a reference video/image for better cont
 python reference_video_similarity.py --videos_folder=... --reference=reference_image.png
 ```
 
-The `--videos_folder` should contain the videos at the top-level. `--reference` can either be an image or a video. You can pass a list of references too:
+The `--videos_folder` should contain the videos at the top-level. `--reference` can either be an image or a video. You can pass a list of references too like so:
 
 ```bash
 python reference_video_similarity.py --videos_folder=... \
-  --reference=reference_image_1.png reference_image_2.png
+  --reference=reference_image_1.png,reference_image_2.png
 ```
+
+As a third option, you can also pass a folder containing the reference images or videos to `--reference`:
+
+```bash
+python reference_video_similarity.py --videos_folder=... --reference=<PATH_TO_FOLDER>
+```
+
+You can vary the `--max_num_frames` and the `--batch_size` arguments to control the memory consumption.
+
+At the end of the execution of the script, you should expect to see parquet file having `video_path`s and the `similarity` scores.
 
 We leverage the vision encoder of SigLIP ([`google/siglip-so400m-patch14-384`](https://hf.co/google/siglip-so400m-patch14-384)) for this.

--- a/video_processing/reference_video_similarity.py
+++ b/video_processing/reference_video_similarity.py
@@ -6,62 +6,82 @@ from tqdm import tqdm
 import numpy as np
 import argparse
 import csv
+import pandas as pd
 from frames import get_frames
 
 
-def compute_video_embedding(frames, model, preprocessor, device, batch_size=0):
+def compute_video_embedding(frames, model, preprocessor, device, dtype):
     """
-    Computes an embedding for a video by averaging the embeddings of its frames.
-    If batch_size > 0, frames are processed in batches; otherwise, all frames are processed at once.
+    Compute video embeddings. `frames` can either be frames of a single video or a list of list of
+    frames from multiple videos.
     """
-    if batch_size and batch_size > 0:
-        embeddings = []
-        for i in range(0, len(frames), batch_size):
-            batch_frames = frames[i : i + batch_size]
-            batch_input = preprocessor(images=batch_frames, return_tensors="pt").to(device)
-            with torch.no_grad() and torch.autocast(torch.device(device).type, dtype=torch.float16):
-                batch_embeddings = model(**batch_input).pooler_output
-                batch_embeddings = batch_embeddings / batch_embeddings.norm(dim=-1, keepdim=True)
-            embeddings.append(batch_embeddings.cpu())
-        embeddings = torch.cat(embeddings, dim=0)
-    else:
-        # Process all frames at once.
-        all_input = preprocessor(images=frames, return_tensors="pt").to(device)
-        with torch.no_grad() and torch.autocast(torch.device(device).type, dtype=torch.float16):
+    if not frames:
+        return None
+
+    if isinstance(frames[0], list):
+        video_embeddings = []
+        flat_frames = []
+        video_lengths = []
+
+        for video in frames:
+            video_lengths.append(len(video))
+            flat_frames.extend(video)
+
+        all_input = preprocessor(images=flat_frames, return_tensors="pt").to(device)
+        with torch.no_grad(), torch.autocast(torch.device(device).type, dtype=dtype):
             embeddings = model(**all_input).pooler_output
             embeddings = embeddings / embeddings.norm(dim=-1, keepdim=True)
         embeddings = embeddings.cpu()
 
-    video_embedding = embeddings.mean(dim=0)
-    video_embedding = video_embedding / video_embedding.norm()
-    return video_embedding.numpy()
+        # Group the embeddings back by video
+        index = 0
+        for length in video_lengths:
+            video_emb = embeddings[index : index + length].mean(dim=0)
+            video_emb = video_emb / video_emb.norm()
+            video_embeddings.append(video_emb.numpy())
+            index += length
+
+        return video_embeddings
+    else:
+        all_input = preprocessor(images=frames, return_tensors="pt").to(device)
+        with torch.no_grad(), torch.autocast(torch.device(device).type, dtype=dtype):
+            embeddings = model(**all_input).pooler_output
+            embeddings = embeddings / embeddings.norm(dim=-1, keepdim=True)
+        embeddings = embeddings.cpu()
+
+        video_embedding = embeddings.mean(dim=0)
+        video_embedding = video_embedding / video_embedding.norm()
+        return video_embedding.numpy()
 
 
-def compute_image_embedding(image_path, model, preprocessor, device):
+def compute_image_embedding(image_path, model, preprocessor, device, dtype):
     """
     Computes an embedding for a single image.
     """
     image = Image.open(image_path).convert("RGB")
     image_input = preprocessor(image, return_tensors="pt").to(device)
-    with torch.no_grad() and torch.autocast(torch.device(device).type, dtype=torch.float16):
+    with torch.no_grad() and torch.autocast(torch.device(device).type, dtype=dtype):
         embedding = model(**image_input).pooler_output
         embedding = embedding / embedding.norm(dim=-1, keepdim=True)
     return embedding.cpu().numpy().flatten()
 
 
-def compute_reference_embedding(ref_path, model, preprocessor, device, batch_size=0):
+def compute_reference_embedding(ref_path, model, preprocessor, device, dtype):
     """
     Computes the embedding for a reference file (image or video).
     """
     video_extensions = (".mp4", ".avi", ".mov", ".mkv")
     if ref_path.lower().endswith(video_extensions):
         frames = get_frames(ref_path)
-        return compute_video_embedding(frames, model, preprocessor, device, batch_size)
+        frames = next(iter(frames))
+        frames = [frame.to_image() for frame in frames]
+        return compute_video_embedding(frames, model, preprocessor, device, dtype)
     else:
-        return compute_image_embedding(ref_path, model, preprocessor, device)
+        return compute_image_embedding(ref_path, model, preprocessor, device, dtype)
 
 
 @torch.no_grad()
+@torch.inference_mode()
 def main(args):
     # List video files in the folder (supports common video extensions)
     video_extensions = (".mp4", ".avi", ".mov", ".mkv")
@@ -70,17 +90,33 @@ def main(args):
         for f in os.listdir(args.videos_folder)
         if f.lower().endswith(video_extensions)
     ]
-
+    print(f"Total video files: {len(video_files)}")
     assert video_files
 
+    # Load model.
     device = "cuda" if torch.cuda.is_available() else "cpu"
-    model = SiglipVisionModel.from_pretrained("google/siglip-so400m-patch14-384").to(device)
+    dtype = (
+        torch.bfloat16 if torch.cuda.is_available() and torch.cuda.get_device_capability()[0] >= 8 else torch.float16
+    )
+    model = SiglipVisionModel.from_pretrained(
+        "google/siglip-so400m-patch14-384", attn_implementation="flash_attention_2"
+    ).to(device)
     preprocessor = SiglipImageProcessor.from_pretrained("google/siglip-so400m-patch14-384")
 
     # Process each reference file and average their embeddings.
     ref_embeddings = []
-    for ref in args.reference:
-        emb = compute_reference_embedding(ref, model, preprocessor, device, args.batch_size)
+    if os.path.isdir(args.reference):
+        allow_extensions = video_extensions + (".png", ".jpg", ".jpeg")
+        reference = [
+            os.path.join(args.reference, f) for f in os.listdir(args.reference) if f.endswith(allow_extensions)
+        ]
+    else:
+        reference = args.reference.split(",")
+
+    assert reference
+
+    for ref in reference:
+        emb = compute_reference_embedding(ref, model, preprocessor, device, dtype)
         if emb is not None:
             ref_embeddings.append(emb)
         else:
@@ -94,32 +130,54 @@ def main(args):
     ref_embedding = ref_embedding / np.linalg.norm(ref_embedding)
 
     results = []
+    batch_frames = []  # To collect frames for a batch of videos
+    batch_paths = []  # To keep track of corresponding video paths
     pbar = tqdm(video_files, desc="Computing video embeddings.")
+
     for video_path in pbar:
         pbar.set_postfix_str(f"{video_path}")
-        frames = next(iter(frames))
-        frames = [frame.to_image() for frame in frames]
-        if len(frames) == 0:
+
+        frames_generator = get_frames(video_path)
+        try:
+            frames_batch = next(iter(frames_generator))
+        except StopIteration:
             print(f"Could not extract frames from {video_path}")
             continue
-        video_embedding = compute_video_embedding(frames, model, preprocessor, device, args.batch_size)
-        if video_embedding is None:
+
+        frames = [frame.to_image() for frame in frames_batch]
+        if not frames:
+            print(f"Could not extract frames from {video_path}")
             continue
-        # Compute cosine similarity between reference and video embeddings.
-        similarity = np.dot(ref_embedding, video_embedding)
-        results.append((video_path, similarity))
+
+        frames = frames[: args.max_num_frames]
+        batch_frames.append(frames)
+        batch_paths.append(video_path)
+
+        if len(batch_frames) == args.batch_size:
+            video_embeddings = compute_video_embedding(batch_frames, model, preprocessor, device, dtype)
+            for path, video_embedding in zip(batch_paths, video_embeddings):
+                if video_embedding is not None:
+                    similarity = np.dot(ref_embedding, video_embedding)
+                    results.append((path.split("/")[-1], similarity))
+            batch_frames = []
+            batch_paths = []
+
+    # Remaining.
+    if batch_frames:
+        video_embeddings = compute_video_embedding(batch_frames, model, preprocessor, device, dtype)
+        for path, video_embedding in zip(batch_paths, video_embeddings):
+            if video_embedding is not None:
+                similarity = np.dot(ref_embedding, video_embedding)
+                results.append((path.split("/")[-1], similarity))
 
     # Sort videos by similarity score (higher means more similar).
     results.sort(key=lambda x: x[1], reverse=True)
 
-    # Write results to CSV.
-    with open(args.output_csv, mode="w", newline="") as csv_file:
-        writer = csv.writer(csv_file)
-        writer.writerow(["video_path", "similarity"])
-        for video, score in results:
-            writer.writerow([video, f"{score:.4f}"])
+    # Write results to a parquet file.
+    df = pd.DataFrame(results, columns=["video_path", "similarity"])
+    df.to_parquet(args.parquet_out_path, index=False, float_format="%.4f")
 
-    print(f"\nResults saved to {args.output_csv}")
+    print(f"\nResults saved to {args.parquet_out_path}")
 
 
 if __name__ == "__main__":
@@ -133,21 +191,26 @@ if __name__ == "__main__":
     parser.add_argument(
         "--reference",
         type=str,
-        nargs="+",
         required=True,
         help="Reference image/video file(s).",
     )
     parser.add_argument(
-        "--batch_size",
+        "--max_num_frames",
         type=int,
-        default=0,
-        help="Batch size for inference (default: process all frames at once).",
+        default=24,
+        help="Max number of frames per videos.",
     )
     parser.add_argument(
-        "--output_csv",
+        "--batch_size",
+        type=int,
+        default=16,
+        help="How many videos to process.",
+    )
+    parser.add_argument(
+        "--parquet_out_path",
         type=str,
-        default="results.csv",
-        help="Path to the output CSV file.",
+        default="results.parquet",
+        help="Path to the output parquet file.",
     )
     args = parser.parse_args()
     main(args)

--- a/video_processing/reference_video_similarity.py
+++ b/video_processing/reference_video_similarity.py
@@ -5,7 +5,6 @@ from PIL import Image
 from tqdm import tqdm
 import numpy as np
 import argparse
-import csv
 import pandas as pd
 from frames import get_frames
 

--- a/video_processing/reference_video_similarity.py
+++ b/video_processing/reference_video_similarity.py
@@ -174,7 +174,7 @@ def main(args):
 
     # Write results to a parquet file.
     df = pd.DataFrame(results, columns=["video_path", "similarity"])
-    df.to_parquet(args.parquet_out_path, index=False, float_format="%.4f")
+    df.to_parquet(args.parquet_out_path, index=False)
 
     print(f"\nResults saved to {args.parquet_out_path}")
 


### PR DESCRIPTION
* Allow a folder to be passed as a reference. Ccing @a-r-r-o-w for awareness as this is a nice flexibility to have IMO.
* Control the autocast dtype based on the compute capability of the hardware.
* Introduce `max_num_frames` and `batch_size` args to control memory consumption to improve throughput. 
* Serialize as a parquet instead of CSV to be consistent with the rest of the settings.